### PR TITLE
Fix nil dereference in fetchMetric

### DIFF
--- a/main.go
+++ b/main.go
@@ -188,9 +188,12 @@ func fetchMetric(ctx context.Context, api *datadogV1.MetricsApi, query string) (
 		// The API call technically succeeded in that the query wasn't malformed.
 		// Note that this doesn't mean the metric is necessarily a real metric, just that the query succeeded.
 		if len(metricResp.Series) > 0 && metricResp.Series[0].End != nil {
-			// Return the value of the latest datapoint in the time series.
-			value := *metricResp.Series[0].Pointlist[len(metricResp.Series[0].Pointlist)-1][1]
-			return datadog.NewNullableFloat64(&value), nil
+			series := metricResp.Series[0]
+			if len(series.Pointlist) > 0 {
+				// Return the value of the latest datapoint in the time series.
+				lastestPoint := series.Pointlist[len(series.Pointlist)-1]
+				return datadog.NewNullableFloat64(lastestPoint[1]), nil
+			}
 		}
 
 		// No time series was returned, so it's probably a metric without data or it doesn't exist.


### PR DESCRIPTION
## Summary
- guard against missing pointlist data when querying metrics

## Testing
- `go test ./...` *(fails: Forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_b_683f9a37bca8832f8677ef364d7fa6ae