### PR TITLE
feat: detect and validate inner queries in default_zero() functions

### DIFF
--- a/ENHANCEMENT.md
+++ b/ENHANCEMENT.md
@@ -1,0 +1,67 @@
+# Enhanced default_zero() Validation
+
+## Problem Solved
+
+Previously, the linter would pass queries wrapped in `default_zero()` even when the inner metric was invalid, because `default_zero()` masks errors by returning 0 instead of failing. This created a blind spot where invalid metrics could pass validation.
+
+## Solution
+
+The enhanced linter now:
+
+1. **Detects `default_zero()` usage**: Identifies when queries use `default_zero()` wrapper functions
+2. **Extracts inner queries**: Removes the `default_zero()` wrapper(s) to get the underlying metric query
+3. **Validates inner queries separately**: Tests the inner query without `default_zero()` to detect masked failures
+4. **Supports nested calls**: Handles multiple levels of `default_zero()` nesting
+5. **Fails appropriately**: Returns non-zero exit code when `default_zero()` masks invalid metrics
+
+## Test Cases Added
+
+### Invalid Metric Detection
+```yaml
+# tests/datadogmetric-default-zero-invalid.yaml
+spec:
+  query: default_zero(avg:completely.invalid.metric.name{nonexistent:tag,invalid:filter})
+```
+**Result**: ❌ Fails linting (inner query is invalid)
+
+### Nested default_zero() Calls
+```yaml  
+# tests/datadogmetric-nested-default-zero-invalid.yaml
+spec:
+  query: default_zero(default_zero(avg:deeply.nested.invalid.metric{fake:tag}))
+```
+**Result**: ❌ Fails linting (supports any level of nesting)
+
+### Malformed Syntax Detection
+```yaml
+# tests/datadogmetric-default-zero-malformed.yaml  
+spec:
+  query: default_zero(avg:metric.name{tag:value}.invalid_function_call())
+```
+**Result**: ❌ Fails linting (syntax error in inner query)
+
+## Implementation Details
+
+### Query Analysis
+- **Regular expressions**: Detect `default_zero()` function calls
+- **Parentheses matching**: Properly extract inner queries from nested calls
+- **Whitespace handling**: Tolerates spaces around function calls
+
+### Validation Flow
+1. Parse and validate original query (maintains backward compatibility)
+2. If `default_zero()` detected, extract inner query
+3. Validate inner query separately via Datadog API
+4. Fail if inner query has syntax errors or metric issues
+5. Warn if inner query returns no data (potential non-existent metric)
+
+### Logging Enhancements
+- **Debug logs**: Show query analysis details including nesting levels
+- **Error logs**: Clear messages when `default_zero()` masks failures  
+- **Warning logs**: Alert when metrics may not exist but syntax is valid
+
+## Benefits
+
+✅ **Prevents false positives**: No more invalid metrics passing due to `default_zero()` masking
+✅ **Maintains compatibility**: Existing functionality unchanged
+✅ **Comprehensive coverage**: Handles simple and complex nested scenarios
+✅ **Clear feedback**: Detailed logging shows exactly what was detected and why it failed

--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ You can also use `find` to get said files:
 ./datadog-query-linter `find ../kubernetes/rendered -type f -name "datadogmetric-*"`
 ```
 
+## Enhanced default_zero() Validation
+
+**New Feature**: The linter now detects when `default_zero()` is used to mask invalid metrics and fails appropriately.
+
+### Problem Solved
+Previously, queries wrapped in `default_zero()` would pass validation even when the inner metric was invalid, because `default_zero()` masks errors by returning 0. This created a blind spot where invalid metrics could pass CI checks.
+
+### Solution
+The enhanced linter now:
+- Detects `default_zero()` usage in queries
+- Extracts and validates inner queries separately  
+- Fails when `default_zero()` masks invalid metrics or syntax errors
+- Supports nested `default_zero()` calls
+- Provides detailed logging about what was detected
+
+See `ENHANCEMENT.md` for detailed technical information.
+
 ## Development
 
 Clone the repo and it should just be ready to go. The Makefile has some assumptions about location of code (like it assume the k8s repo is in the parent directory), but otherwise it should work fine.

--- a/main_test.go
+++ b/main_test.go
@@ -50,6 +50,8 @@ func TestQueryParsing(t *testing.T) {
 		expectDefaultZero bool
 		expectedInner     string
 		expectedNesting   int
+		expectComplex     bool
+		expectedMetrics   int
 	}{
 		{
 			name:              "simple query without default_zero",
@@ -57,6 +59,8 @@ func TestQueryParsing(t *testing.T) {
 			expectDefaultZero: false,
 			expectedInner:     "",
 			expectedNesting:   0,
+			expectComplex:     false,
+			expectedMetrics:   1,
 		},
 		{
 			name:              "query with default_zero",
@@ -64,6 +68,8 @@ func TestQueryParsing(t *testing.T) {
 			expectDefaultZero: true,
 			expectedInner:     "avg:system.cpu.user{*}",
 			expectedNesting:   1,
+			expectComplex:     false,
+			expectedMetrics:   1,
 		},
 		{
 			name:              "query with nested default_zero",
@@ -71,6 +77,35 @@ func TestQueryParsing(t *testing.T) {
 			expectDefaultZero: true,
 			expectedInner:     "avg:system.cpu.user{*}",
 			expectedNesting:   2,
+			expectComplex:     false,
+			expectedMetrics:   1,
+		},
+		{
+			name:              "complex query with multiple metrics",
+			query:             "avg:system.cpu.user{*} + avg:system.cpu.system{*}",
+			expectDefaultZero: false,
+			expectedInner:     "avg:system.cpu.user{*}",
+			expectedNesting:   0,
+			expectComplex:     true,
+			expectedMetrics:   2,
+		},
+		{
+			name:              "complex query with default_zero wrapped metrics",
+			query:             "(default_zero(default_zero(avg:deeply.nested.valid.metric1{fake:tag}))+default_zero(default_zero(avg:deeply.nested.valid.metric2{fake:tag})))/default_zero(avg:deeply.nested.valid.metric3{fake:tag})",
+			expectDefaultZero: true,
+			expectedInner:     "avg:deeply.nested.valid.metric1{fake:tag}",
+			expectedNesting:   2,
+			expectComplex:     true,
+			expectedMetrics:   3,
+		},
+		{
+			name:              "mixed metrics with some default_zero",
+			query:             "default_zero(avg:valid.metric{tag:value}) * sum:another.metric{env:prod} / count:third.metric{*}",
+			expectDefaultZero: true,
+			expectedInner:     "avg:valid.metric{tag:value}",
+			expectedNesting:   1,
+			expectComplex:     true,
+			expectedMetrics:   3,
 		},
 		{
 			name:              "complex query with default_zero",
@@ -78,6 +113,8 @@ func TestQueryParsing(t *testing.T) {
 			expectDefaultZero: true,
 			expectedInner:     "avg:rails.temporal.workflow_task.queue_time.avg{app:persona-web-temporal-worker-retention,env:production,region:us-central1,task_queue:retention}.fill(null)",
 			expectedNesting:   1,
+			expectComplex:     false,
+			expectedMetrics:   1,
 		},
 		{
 			name:              "query with spaces around default_zero",
@@ -85,6 +122,8 @@ func TestQueryParsing(t *testing.T) {
 			expectDefaultZero: true,
 			expectedInner:     "avg:system.cpu.user{*}",
 			expectedNesting:   1,
+			expectComplex:     false,
+			expectedMetrics:   1,
 		},
 		{
 			name:              "query starting with default_zero but not function call",
@@ -92,6 +131,8 @@ func TestQueryParsing(t *testing.T) {
 			expectDefaultZero: false,
 			expectedInner:     "",
 			expectedNesting:   0,
+			expectComplex:     false,
+			expectedMetrics:   1,
 		},
 	}
 
@@ -113,6 +154,14 @@ func TestQueryParsing(t *testing.T) {
 
 			if analysis.OriginalQuery != tt.query {
 				t.Errorf("Expected OriginalQuery=%q, got %q", tt.query, analysis.OriginalQuery)
+			}
+
+			if analysis.IsComplexQuery != tt.expectComplex {
+				t.Errorf("Expected IsComplexQuery=%v, got %v", tt.expectComplex, analysis.IsComplexQuery)
+			}
+
+			if len(analysis.Metrics) != tt.expectedMetrics {
+				t.Errorf("Expected %d metrics, got %d", tt.expectedMetrics, len(analysis.Metrics))
 			}
 		})
 	}
@@ -170,6 +219,267 @@ func TestExtractInnerQuery(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestComplexQueryDetection(t *testing.T) {
+	tests := []struct {
+		name       string
+		query      string
+		isComplex  bool
+	}{
+		{
+			name:      "simple metric",
+			query:     "avg:system.cpu.user{*}",
+			isComplex: false,
+		},
+		{
+			name:      "simple metric with default_zero",
+			query:     "default_zero(avg:system.cpu.user{*})",
+			isComplex: false,
+		},
+		{
+			name:      "two metrics with addition",
+			query:     "avg:system.cpu.user{*} + avg:system.cpu.system{*}",
+			isComplex: true,
+		},
+		{
+			name:      "complex expression with parentheses",
+			query:     "(avg:metric1{*} + avg:metric2{*}) / sum:metric3{*}",
+			isComplex: true,
+		},
+		{
+			name:      "your example query",
+			query:     "(default_zero(default_zero(avg:deeply.nested.valid.metric1{fake:tag}))+default_zero(default_zero(avg:deeply.nested.valid.metric2{fake:tag})))/default_zero(avg:deeply.nested.valid.metric3{fake:tag})",
+			isComplex: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isComplexQuery(tt.query)
+			if result != tt.isComplex {
+				t.Errorf("Expected isComplex=%v, got %v for query: %s", tt.isComplex, result, tt.query)
+			}
+		})
+	}
+}
+
+func TestExtractAllMetrics(t *testing.T) {
+	tests := []struct {
+		name            string
+		query           string
+		expectedMetrics []struct {
+			originalMetric     string
+			cleanMetric        string
+			hasDefaultZero     bool
+			defaultZeroNesting int
+		}
+	}{
+		{
+			name:  "simple addition",
+			query: "avg:system.cpu.user{*} + avg:system.cpu.system{*}",
+			expectedMetrics: []struct {
+				originalMetric     string
+				cleanMetric        string
+				hasDefaultZero     bool
+				defaultZeroNesting int
+			}{
+				{
+					originalMetric:     "avg:system.cpu.user{*}",
+					cleanMetric:        "avg:system.cpu.user{*}",
+					hasDefaultZero:     false,
+					defaultZeroNesting: 0,
+				},
+				{
+					originalMetric:     "avg:system.cpu.system{*}",
+					cleanMetric:        "avg:system.cpu.system{*}",
+					hasDefaultZero:     false,
+					defaultZeroNesting: 0,
+				},
+			},
+		},
+		{
+			name:  "complex query with default_zero",
+			query: "(default_zero(default_zero(avg:deeply.nested.valid.metric1{fake:tag}))+default_zero(default_zero(avg:deeply.nested.valid.metric2{fake:tag})))/default_zero(avg:deeply.nested.valid.metric3{fake:tag})",
+			expectedMetrics: []struct {
+				originalMetric     string
+				cleanMetric        string
+				hasDefaultZero     bool
+				defaultZeroNesting int
+			}{
+				{
+					originalMetric:     "default_zero(default_zero(avg:deeply.nested.valid.metric1{fake:tag}))",
+					cleanMetric:        "avg:deeply.nested.valid.metric1{fake:tag}",
+					hasDefaultZero:     true,
+					defaultZeroNesting: 2,
+				},
+				{
+					originalMetric:     "default_zero(default_zero(avg:deeply.nested.valid.metric2{fake:tag}))",
+					cleanMetric:        "avg:deeply.nested.valid.metric2{fake:tag}",
+					hasDefaultZero:     true,
+					defaultZeroNesting: 2,
+				},
+				{
+					originalMetric:     "default_zero(avg:deeply.nested.valid.metric3{fake:tag})",
+					cleanMetric:        "avg:deeply.nested.valid.metric3{fake:tag}",
+					hasDefaultZero:     true,
+					defaultZeroNesting: 1,
+				},
+			},
+		},
+		{
+			name:  "mixed default_zero and normal metrics",
+			query: "default_zero(avg:valid.metric{tag:value}) * sum:another.metric{env:prod} / count:third.metric{*}",
+			expectedMetrics: []struct {
+				originalMetric     string
+				cleanMetric        string
+				hasDefaultZero     bool
+				defaultZeroNesting int
+			}{
+				{
+					originalMetric:     "default_zero(avg:valid.metric{tag:value})",
+					cleanMetric:        "avg:valid.metric{tag:value}",
+					hasDefaultZero:     true,
+					defaultZeroNesting: 1,
+				},
+				{
+					originalMetric:     "sum:another.metric{env:prod}",
+					cleanMetric:        "sum:another.metric{env:prod}",
+					hasDefaultZero:     false,
+					defaultZeroNesting: 0,
+				},
+				{
+					originalMetric:     "count:third.metric{*}",
+					cleanMetric:        "count:third.metric{*}",
+					hasDefaultZero:     false,
+					defaultZeroNesting: 0,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := extractAllMetrics(tt.query)
+
+			if len(metrics) != len(tt.expectedMetrics) {
+				t.Errorf("Expected %d metrics, got %d", len(tt.expectedMetrics), len(metrics))
+				for i, m := range metrics {
+					t.Logf("Metric %d: %+v", i, m)
+				}
+				return
+			}
+
+			for i, expected := range tt.expectedMetrics {
+				metric := metrics[i]
+
+				if metric.CleanMetric != expected.cleanMetric {
+					t.Errorf("Metric %d: Expected CleanMetric=%q, got %q", i, expected.cleanMetric, metric.CleanMetric)
+				}
+
+				if metric.HasDefaultZero != expected.hasDefaultZero {
+					t.Errorf("Metric %d: Expected HasDefaultZero=%v, got %v", i, expected.hasDefaultZero, metric.HasDefaultZero)
+				}
+
+				if metric.DefaultZeroNesting != expected.defaultZeroNesting {
+					t.Errorf("Metric %d: Expected DefaultZeroNesting=%d, got %d", i, expected.defaultZeroNesting, metric.DefaultZeroNesting)
+				}
+			}
+		})
+	}
+}
+
+func TestMultiMetricTestFiles(t *testing.T) {
+	t.Run("extract query from multi-metric complex file", func(t *testing.T) {
+		query, err := extractQuery("tests/datadogmetric-multi-metric-complex.yaml")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		expectedQuery := "(default_zero(default_zero(avg:deeply.nested.valid.metric1{fake:tag}))+default_zero(default_zero(avg:deeply.nested.valid.metric2{fake:tag})))/default_zero(avg:deeply.nested.valid.metric3{fake:tag})"
+		if query != expectedQuery {
+			t.Errorf("Expected query %q, got %q", expectedQuery, query)
+		}
+
+		// Test that the query is properly parsed as complex
+		analysis := parseQuery(query)
+		if !analysis.IsComplexQuery {
+			t.Error("Expected query to be detected as complex")
+		}
+
+		if len(analysis.Metrics) != 3 {
+			t.Errorf("Expected 3 metrics, got %d", len(analysis.Metrics))
+		}
+
+		// Verify all metrics have default_zero
+		for i, metric := range analysis.Metrics {
+			if !metric.HasDefaultZero {
+				t.Errorf("Metric %d should have default_zero", i)
+			}
+		}
+	})
+
+	t.Run("extract query from multi-metric simple file", func(t *testing.T) {
+		query, err := extractQuery("tests/datadogmetric-multi-metric-simple.yaml")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		expectedQuery := "avg:system.cpu.user{*} + avg:system.cpu.system{*}"
+		if query != expectedQuery {
+			t.Errorf("Expected query %q, got %q", expectedQuery, query)
+		}
+
+		// Test that the query is properly parsed as complex
+		analysis := parseQuery(query)
+		if !analysis.IsComplexQuery {
+			t.Error("Expected query to be detected as complex")
+		}
+
+		if len(analysis.Metrics) != 2 {
+			t.Errorf("Expected 2 metrics, got %d", len(analysis.Metrics))
+		}
+
+		// Verify no metrics have default_zero
+		for i, metric := range analysis.Metrics {
+			if metric.HasDefaultZero {
+				t.Errorf("Metric %d should not have default_zero", i)
+			}
+		}
+	})
+
+	t.Run("extract query from mixed metrics file", func(t *testing.T) {
+		query, err := extractQuery("tests/datadogmetric-mixed-metrics.yaml")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		expectedQuery := "default_zero(avg:valid.metric{tag:value}) * sum:another.metric{env:prod} / count:third.metric{*}"
+		if query != expectedQuery {
+			t.Errorf("Expected query %q, got %q", expectedQuery, query)
+		}
+
+		// Test that the query is properly parsed as complex
+		analysis := parseQuery(query)
+		if !analysis.IsComplexQuery {
+			t.Error("Expected query to be detected as complex")
+		}
+
+		if len(analysis.Metrics) != 3 {
+			t.Errorf("Expected 3 metrics, got %d", len(analysis.Metrics))
+		}
+
+		// Verify first metric has default_zero, others don't
+		if !analysis.Metrics[0].HasDefaultZero {
+			t.Error("First metric should have default_zero")
+		}
+		if analysis.Metrics[1].HasDefaultZero {
+			t.Error("Second metric should not have default_zero")
+		}
+		if analysis.Metrics[2].HasDefaultZero {
+			t.Error("Third metric should not have default_zero")
+		}
+	})
 }
 
 func TestDefaultZeroTestFiles(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -43,6 +43,210 @@ func TestFileLoading(t *testing.T) {
 	})
 }
 
+func TestQueryParsing(t *testing.T) {
+	tests := []struct {
+		name              string
+		query             string
+		expectDefaultZero bool
+		expectedInner     string
+		expectedNesting   int
+	}{
+		{
+			name:              "simple query without default_zero",
+			query:             "avg:system.cpu.user{*}",
+			expectDefaultZero: false,
+			expectedInner:     "",
+			expectedNesting:   0,
+		},
+		{
+			name:              "query with default_zero",
+			query:             "default_zero(avg:system.cpu.user{*})",
+			expectDefaultZero: true,
+			expectedInner:     "avg:system.cpu.user{*}",
+			expectedNesting:   1,
+		},
+		{
+			name:              "query with nested default_zero",
+			query:             "default_zero(default_zero(avg:system.cpu.user{*}))",
+			expectDefaultZero: true,
+			expectedInner:     "avg:system.cpu.user{*}",
+			expectedNesting:   2,
+		},
+		{
+			name:              "complex query with default_zero",
+			query:             "default_zero(avg:rails.temporal.workflow_task.queue_time.avg{app:persona-web-temporal-worker-retention,env:production,region:us-central1,task_queue:retention}.fill(null))",
+			expectDefaultZero: true,
+			expectedInner:     "avg:rails.temporal.workflow_task.queue_time.avg{app:persona-web-temporal-worker-retention,env:production,region:us-central1,task_queue:retention}.fill(null)",
+			expectedNesting:   1,
+		},
+		{
+			name:              "query with spaces around default_zero",
+			query:             "default_zero( avg:system.cpu.user{*} )",
+			expectDefaultZero: true,
+			expectedInner:     "avg:system.cpu.user{*}",
+			expectedNesting:   1,
+		},
+		{
+			name:              "query starting with default_zero but not function call",
+			query:             "default_zero_custom_function(avg:system.cpu.user{*})",
+			expectDefaultZero: false,
+			expectedInner:     "",
+			expectedNesting:   0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			analysis := parseQuery(tt.query)
+
+			if analysis.HasDefaultZero != tt.expectDefaultZero {
+				t.Errorf("Expected HasDefaultZero=%v, got %v", tt.expectDefaultZero, analysis.HasDefaultZero)
+			}
+
+			if analysis.InnerQuery != tt.expectedInner {
+				t.Errorf("Expected InnerQuery=%q, got %q", tt.expectedInner, analysis.InnerQuery)
+			}
+
+			if analysis.DefaultZeroNesting != tt.expectedNesting {
+				t.Errorf("Expected DefaultZeroNesting=%d, got %d", tt.expectedNesting, analysis.DefaultZeroNesting)
+			}
+
+			if analysis.OriginalQuery != tt.query {
+				t.Errorf("Expected OriginalQuery=%q, got %q", tt.query, analysis.OriginalQuery)
+			}
+		})
+	}
+}
+
+func TestExtractInnerQuery(t *testing.T) {
+	tests := []struct {
+		name            string
+		query           string
+		expectedInner   string
+		expectedNesting int
+	}{
+		{
+			name:            "single default_zero",
+			query:           "default_zero(avg:system.cpu.user{*})",
+			expectedInner:   "avg:system.cpu.user{*}",
+			expectedNesting: 1,
+		},
+		{
+			name:            "double nested default_zero",
+			query:           "default_zero(default_zero(avg:system.cpu.user{*}))",
+			expectedInner:   "avg:system.cpu.user{*}",
+			expectedNesting: 2,
+		},
+		{
+			name:            "triple nested default_zero",
+			query:           "default_zero(default_zero(default_zero(avg:system.cpu.user{*})))",
+			expectedInner:   "avg:system.cpu.user{*}",
+			expectedNesting: 3,
+		},
+		{
+			name:            "complex inner query",
+			query:           "default_zero(sum:docker.containers.running{image_name:web}.as_count())",
+			expectedInner:   "sum:docker.containers.running{image_name:web}.as_count()",
+			expectedNesting: 1,
+		},
+		{
+			name:            "query without default_zero",
+			query:           "avg:system.cpu.user{*}",
+			expectedInner:   "avg:system.cpu.user{*}",
+			expectedNesting: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inner, nesting := extractInnerQuery(tt.query)
+
+			if inner != tt.expectedInner {
+				t.Errorf("Expected inner query=%q, got %q", tt.expectedInner, inner)
+			}
+
+			if nesting != tt.expectedNesting {
+				t.Errorf("Expected nesting=%d, got %d", tt.expectedNesting, nesting)
+			}
+		})
+	}
+}
+
+func TestDefaultZeroTestFiles(t *testing.T) {
+	t.Run("extract query from default_zero invalid metric file", func(t *testing.T) {
+		query, err := extractQuery("tests/datadogmetric-default-zero-invalid.yaml")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		expectedQuery := "default_zero(avg:completely.invalid.metric.name{nonexistent:tag,invalid:filter})"
+		if query != expectedQuery {
+			t.Errorf("Expected query %q, got %q", expectedQuery, query)
+		}
+
+		// Test that the query is properly parsed
+		analysis := parseQuery(query)
+		if !analysis.HasDefaultZero {
+			t.Error("Expected query to be detected as having default_zero")
+		}
+
+		expectedInner := "avg:completely.invalid.metric.name{nonexistent:tag,invalid:filter}"
+		if analysis.InnerQuery != expectedInner {
+			t.Errorf("Expected inner query %q, got %q", expectedInner, analysis.InnerQuery)
+		}
+	})
+
+	t.Run("extract query from nested default_zero invalid metric file", func(t *testing.T) {
+		query, err := extractQuery("tests/datadogmetric-nested-default-zero-invalid.yaml")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		expectedQuery := "default_zero(default_zero(avg:deeply.nested.invalid.metric{fake:tag}))"
+		if query != expectedQuery {
+			t.Errorf("Expected query %q, got %q", expectedQuery, query)
+		}
+
+		// Test that the query is properly parsed with nesting
+		analysis := parseQuery(query)
+		if !analysis.HasDefaultZero {
+			t.Error("Expected query to be detected as having default_zero")
+		}
+
+		expectedInner := "avg:deeply.nested.invalid.metric{fake:tag}"
+		if analysis.InnerQuery != expectedInner {
+			t.Errorf("Expected inner query %q, got %q", expectedInner, analysis.InnerQuery)
+		}
+
+		if analysis.DefaultZeroNesting != 2 {
+			t.Errorf("Expected nesting level 2, got %d", analysis.DefaultZeroNesting)
+		}
+	})
+
+	t.Run("extract query from default_zero malformed syntax file", func(t *testing.T) {
+		query, err := extractQuery("tests/datadogmetric-default-zero-malformed.yaml")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		expectedQuery := "default_zero(avg:metric.name{tag:value}.invalid_function_call())"
+		if query != expectedQuery {
+			t.Errorf("Expected query %q, got %q", expectedQuery, query)
+		}
+
+		// Test that the query is properly parsed
+		analysis := parseQuery(query)
+		if !analysis.HasDefaultZero {
+			t.Error("Expected query to be detected as having default_zero")
+		}
+
+		expectedInner := "avg:metric.name{tag:value}.invalid_function_call()"
+		if analysis.InnerQuery != expectedInner {
+			t.Errorf("Expected inner query %q, got %q", expectedInner, analysis.InnerQuery)
+		}
+	})
+}
+
 // TODO: figure out how to mock calls to datadog so we don't need to use our API keys in the tests.
 func TestMetricFetching(t *testing.T) {
 	t.SkipNow()

--- a/tests/datadogmetric-default-zero-invalid.yaml
+++ b/tests/datadogmetric-default-zero-invalid.yaml
@@ -1,0 +1,8 @@
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogMetric
+metadata:
+  name: default-zero-invalid-metric
+  namespace: web
+spec:
+  # This query uses default_zero() to mask an invalid metric that should fail linting
+  query: default_zero(avg:completely.invalid.metric.name{nonexistent:tag,invalid:filter})

--- a/tests/datadogmetric-default-zero-malformed.yaml
+++ b/tests/datadogmetric-default-zero-malformed.yaml
@@ -1,0 +1,8 @@
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogMetric
+metadata:
+  name: default-zero-malformed-syntax
+  namespace: web
+spec:
+  # This query uses default_zero() with malformed syntax that should fail
+  query: default_zero(avg:metric.name{tag:value}.invalid_function_call())

--- a/tests/datadogmetric-mixed-metrics.yaml
+++ b/tests/datadogmetric-mixed-metrics.yaml
@@ -1,0 +1,6 @@
+apiVersion: argoproj.io/v1alpha1
+kind: DatadogMetric
+metadata:
+  name: test-mixed-metrics
+spec:
+  query: "default_zero(avg:valid.metric{tag:value}) * sum:another.metric{env:prod} / count:third.metric{*}"

--- a/tests/datadogmetric-multi-metric-complex.yaml
+++ b/tests/datadogmetric-multi-metric-complex.yaml
@@ -1,0 +1,6 @@
+apiVersion: argoproj.io/v1alpha1
+kind: DatadogMetric
+metadata:
+  name: test-multi-metric-complex
+spec:
+  query: "(default_zero(default_zero(avg:deeply.nested.valid.metric1{fake:tag}))+default_zero(default_zero(avg:deeply.nested.valid.metric2{fake:tag})))/default_zero(avg:deeply.nested.valid.metric3{fake:tag})"

--- a/tests/datadogmetric-multi-metric-simple.yaml
+++ b/tests/datadogmetric-multi-metric-simple.yaml
@@ -1,0 +1,6 @@
+apiVersion: argoproj.io/v1alpha1
+kind: DatadogMetric
+metadata:
+  name: test-multi-metric-simple
+spec:
+  query: "avg:system.cpu.user{*} + avg:system.cpu.system{*}"

--- a/tests/datadogmetric-nested-default-zero-invalid.yaml
+++ b/tests/datadogmetric-nested-default-zero-invalid.yaml
@@ -1,0 +1,8 @@
+apiVersion: datadoghq.com/v1alpha1
+kind: DatadogMetric
+metadata:
+  name: nested-default-zero-invalid-metric
+  namespace: web
+spec:
+  # This query uses nested default_zero() calls to mask an invalid metric
+  query: default_zero(default_zero(avg:deeply.nested.invalid.metric{fake:tag}))


### PR DESCRIPTION
- Add query parsing to detect default_zero() usage and extract inner queries
- Validate inner queries separately to catch metrics masked by default_zero()
- Support nested default_zero() calls with proper parentheses matching
- Fail linting when default_zero() masks invalid metrics or syntax errors
- Add comprehensive test suite with edge cases and nested scenarios
- Enhance logging with debug info for query analysis and validation

BREAKING CHANGE: Linter now fails for invalid metrics wrapped in default_zero()
that previously passed validation

Resolves issue where default_zero() masked invalid metrics in CI pipelines
